### PR TITLE
Add option to allow unquoted control characters in strings

### DIFF
--- a/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/HighspeedJSONEditorActivator.java
+++ b/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/HighspeedJSONEditorActivator.java
@@ -49,7 +49,7 @@ public class HighspeedJSONEditorActivator extends AbstractUIPlugin {
 		super.start(context);
 		plugin = this;
 		
-		HighspeedJSONEditorUtil.refreshAllowCommentsState();
+		HighspeedJSONEditorUtil.refreshParserSettings();
 		
 	}
 

--- a/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/HighspeedJSONEditorUtil.java
+++ b/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/HighspeedJSONEditorUtil.java
@@ -124,7 +124,7 @@ public class HighspeedJSONEditorUtil {
             logError("Was not able to add error markers", e);
         }
     }
-    
+
     public static void addErrorMarker(int line, String message, IEditorInput input, int start, int end) {
         if (input == null) {
             return;
@@ -148,8 +148,9 @@ public class HighspeedJSONEditorUtil {
         return log;
     }
 
-    public static void refreshAllowCommentsState() {
+    public static void refreshParserSettings() {
         JSONFormatSupport.DEFAULT.setAllowComents(HighspeedJSONEditorPreferences.getInstance().isAllowingComments());
+        JSONFormatSupport.DEFAULT.setAllowUnquotedControlChars(HighspeedJSONEditorPreferences.getInstance().isAllowingUnquotedControlChars());
     }
 
 }

--- a/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferenceConstants.java
+++ b/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferenceConstants.java
@@ -25,6 +25,7 @@ public enum HighspeedJSONEditorPreferenceConstants implements PreferenceIdentifi
 	
 	P_EDITOR_MATCHING_BRACKETS_ENABLED("matchingBrackets"),
 	P_EDITOR_ALLOW_COMMENTS_ENABLED("allowComments"),
+	P_EDITOR_ALLOW_UNQUOTED_CONTROL_CHARS("allowUnquotedControlChars"),
 	P_EDITOR_HIGHLIGHT_BRACKET_AT_CARET_LOCATION("highlightBracketAtCaretLocation"),
 	P_EDITOR_ENCLOSING_BRACKETS("enclosingBrackets"),
 	P_EDITOR_MATCHING_BRACKETS_COLOR("matchingBracketsColor"),

--- a/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferenceInitializer.java
+++ b/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferenceInitializer.java
@@ -39,6 +39,7 @@ public class HighspeedJSONEditorPreferenceInitializer extends AbstractPreference
 		store.setDefault(P_CREATE_OUTLINE_FOR_NEW_EDITOR.getId(), false); // per default no outline created - increases speed, reduces memory consumption
 		/* PARSING */
 		store.setDefault(P_EDITOR_ALLOW_COMMENTS_ENABLED.getId(), true);
+		store.setDefault(P_EDITOR_ALLOW_UNQUOTED_CONTROL_CHARS.getId(), false);
 		/* VALIDATION*/
 		store.setDefault(P_VALIDATE_ON_SAVE.getId(), true);
 		

--- a/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferencePage.java
+++ b/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferencePage.java
@@ -72,6 +72,7 @@ public class HighspeedJSONEditorPreferencePage extends FieldEditorPreferencePage
 	private boolean highlightBracketAtCaretLocation;
 	private boolean matchingBrackets;
 	private BooleanFieldEditor allowComments;
+	private BooleanFieldEditor allowUnquotedControlChars;
 	private BooleanFieldEditor validateOnSave;
 	private BooleanFieldEditor autoCreateEndBrackets;
 	private BooleanFieldEditor codeAssistWithHighspeedJSONKeywords;
@@ -100,8 +101,8 @@ public class HighspeedJSONEditorPreferencePage extends FieldEditorPreferencePage
 			setBoolean(P_EDITOR_MATCHING_BRACKETS_ENABLED, matchingBrackets);
 			setBoolean(P_EDITOR_HIGHLIGHT_BRACKET_AT_CARET_LOCATION, highlightBracketAtCaretLocation);
 			setBoolean(P_EDITOR_ENCLOSING_BRACKETS, enclosingBrackets);
-			
-			HighspeedJSONEditorUtil.refreshAllowCommentsState();
+
+			HighspeedJSONEditorUtil.refreshParserSettings();
 		}
 		return ok;
 	}
@@ -147,6 +148,13 @@ public class HighspeedJSONEditorPreferencePage extends FieldEditorPreferencePage
 		allowComments.getDescriptionControl(otherComposite)
 		.setToolTipText("When enabled comments are allowed");
 		addField(allowComments);
+
+		/* parsing, allow newlines in strings */
+		allowUnquotedControlChars = new BooleanFieldEditor(P_EDITOR_ALLOW_UNQUOTED_CONTROL_CHARS.getId(),
+		        "Allow unquoted control characters", otherComposite);
+		allowUnquotedControlChars.getDescriptionControl(otherComposite)
+		.setToolTipText("When enabled, unquoted control characters (newlines, tabs, etc.) in strings are allowed");
+		addField(allowUnquotedControlChars);
 
 		/* validate */
 		validateOnSave = new BooleanFieldEditor(P_VALIDATE_ON_SAVE.getId(),

--- a/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferences.java
+++ b/highspeed-json-editor-plugin/src/main/java-eclipse/de/jcup/hijson/preferences/HighspeedJSONEditorPreferences.java
@@ -66,7 +66,11 @@ public class HighspeedJSONEditorPreferences {
 	public boolean isAllowingComments() {
 	    return getBooleanPreference(P_EDITOR_ALLOW_COMMENTS_ENABLED);
 	}
-	
+
+	public boolean isAllowingUnquotedControlChars() {
+	    return getBooleanPreference(P_EDITOR_ALLOW_UNQUOTED_CONTROL_CHARS);
+	}
+
 	public IPreferenceStore getPreferenceStore() {
 		return store;
 	}

--- a/highspeed-json-editor-plugin/src/main/java/de/jcup/hijson/document/JSONFormatSupport.java
+++ b/highspeed-json-editor-plugin/src/main/java/de/jcup/hijson/document/JSONFormatSupport.java
@@ -67,6 +67,14 @@ public class JSONFormatSupport {
         }
     }
 
+    public void setAllowUnquotedControlChars(boolean allowNewlines) {
+        if (allowNewlines) {
+            mapper.enable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
+        } else {
+            mapper.disable(com.fasterxml.jackson.core.JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS);
+        }
+    }
+
     public FormatterResult formatJSONIfNotHavingMinAmountOfNewLines(String str) {
         return formatJSONIfNotHavingMinAmountOfNewLines(str, 3, 1000);
     }


### PR DESCRIPTION
I tried to match formatting around the places I changed.

Some other things I noticed:
- I'm currently using the deprecated `JsonParser.Feature.ALLOW_UNQUOTED_CONTROL_CHARS`, since the ObjectMapper in `JSONFormatSupport` is handled as mutable. Would probably be nice to refactor that to use a `JsonMapper.builder()` in the future...
- The ObjectMapper in JSONFormatSupport is currently static, that seems wrong to me...
- Formatting is a bit over the place, in some files I had to use TABs, in some spaces...

I might come back with other small changes in the future. Is it okay to put some formatting options into the existing preference pane or should I create a new page? (I don't think we need full-blown formatter profile handling, right?)